### PR TITLE
Fix warning

### DIFF
--- a/src/Departements/Datasource/JsonDatasource.php
+++ b/src/Departements/Datasource/JsonDatasource.php
@@ -33,6 +33,10 @@ class JsonDatasource extends AbstractDatasource implements DatasourceInterface
 
                 $region->addDepartement($departement);
 
+                if (!isset($deptDatas['cities'])) {
+                    $deptDatas['cities'] = array();
+                }
+                
                 // add cities
                 foreach($deptDatas['cities'] as $zipcode => $cities) {
                     $communes = new Sequence();


### PR DESCRIPTION
Fix warning fired when looping on inexisting 'cities' datajson index.